### PR TITLE
Add list page with category filters

### DIFF
--- a/src/app/list/page.tsx
+++ b/src/app/list/page.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useState } from "react";
+import { Checkbox } from "@/components/ui/checkbox";
+import { FeaturedCard } from "@/components/featured-card";
+import {
+  CATEGORY_OPTIONS,
+  CATEGORY_RULES,
+  CATEGORY_PROMPTS,
+  CATEGORY_LIBRARIES,
+  CategoryOption,
+} from "@/constants/categories";
+import {
+  featuredRules,
+  featuredPrompts,
+  featuredLibraries,
+} from "@/data/featured-data";
+
+const categoryMap = {
+  [CATEGORY_RULES]: { items: featuredRules, type: "rule" },
+  [CATEGORY_PROMPTS]: { items: featuredPrompts, type: "prompt" },
+  [CATEGORY_LIBRARIES]: { items: featuredLibraries, type: "library" },
+} as const;
+
+export default function ListPage() {
+  const [selected, setSelected] = useState<CategoryOption[]>([
+    CATEGORY_RULES,
+    CATEGORY_PROMPTS,
+    CATEGORY_LIBRARIES,
+  ]);
+
+  const toggleCategory = (category: CategoryOption) => {
+    setSelected((prev) =>
+      prev.includes(category)
+        ? prev.filter((c) => c !== category)
+        : [...prev, category]
+    );
+  };
+
+  const items = selected.flatMap((category) => {
+    const { items, type } = categoryMap[category];
+    return items.map((item) => ({ item, type }));
+  });
+
+  return (
+    <div className="flex p-8 gap-8">
+      <aside className="w-48 space-y-4">
+        {CATEGORY_OPTIONS.map((cat) => (
+          <label key={cat} className="flex items-center space-x-2">
+            <Checkbox
+              checked={selected.includes(cat)}
+              onCheckedChange={() => toggleCategory(cat)}
+            />
+            <span>{cat}</span>
+          </label>
+        ))}
+      </aside>
+      <main className="flex-1 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {items.map(({ item, type }) => (
+          <FeaturedCard key={item.id} item={item as any} type={type} />
+        ))}
+      </main>
+    </div>
+  );
+}

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -9,6 +9,11 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Github, Menu, Moon } from "lucide-react";
+import {
+  CATEGORY_RULES,
+  CATEGORY_PROMPTS,
+  CATEGORY_LIBRARIES,
+} from "@/constants/categories";
 
 export function Header() {
   return (
@@ -30,7 +35,7 @@ export function Header() {
               href="/"
               className="text-gray-300 hover:text-white transition-colors duration-200"
             >
-              Rules
+              {CATEGORY_RULES}
             </Link>
             <Link
               href="/generate"
@@ -114,7 +119,7 @@ export function Header() {
                 </DropdownMenuTrigger>
                 <DropdownMenuContent className="bg-gray-800 border-gray-700">
                   <DropdownMenuItem className="text-gray-300 hover:text-white hover:bg-gray-700">
-                    Rules
+                    {CATEGORY_RULES}
                   </DropdownMenuItem>
                   <DropdownMenuItem className="text-gray-300 hover:text-white hover:bg-gray-700">
                     Generate

--- a/src/components/load-more-button.tsx
+++ b/src/components/load-more-button.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Loader2 } from "lucide-react";
+import { CATEGORY_RULES } from "@/constants/categories";
 
 interface LoadMoreButtonProps {
   onLoadMore: () => Promise<void>;
@@ -41,7 +42,7 @@ export function LoadMoreButton({ onLoadMore, hasMore }: LoadMoreButtonProps) {
             Loading more...
           </>
         ) : (
-          "Load More Rules"
+          `Load More ${CATEGORY_RULES}`
         )}
       </Button>
     </div>

--- a/src/components/modern-header.tsx
+++ b/src/components/modern-header.tsx
@@ -5,14 +5,19 @@ import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Menu, X } from "lucide-react";
 import Image from "next/image";
+import {
+  CATEGORY_RULES,
+  CATEGORY_PROMPTS,
+  CATEGORY_LIBRARIES,
+} from "@/constants/categories";
 
 export function ModernHeader() {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 
   const navigationItems = [
-    { href: "#featured-rules", label: "Rules" },
-    { href: "#featured-prompts", label: "Prompts" },
-    { href: "#featured-libraries", label: "Libraries" },
+    { href: "#featured-rules", label: CATEGORY_RULES },
+    { href: "#featured-prompts", label: CATEGORY_PROMPTS },
+    { href: "#featured-libraries", label: CATEGORY_LIBRARIES },
   ];
 
   return (

--- a/src/components/modern-hero-section.tsx
+++ b/src/components/modern-hero-section.tsx
@@ -4,6 +4,11 @@ import { useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Search } from "lucide-react";
+import {
+  CATEGORY_RULES,
+  CATEGORY_PROMPTS,
+  CATEGORY_LIBRARIES,
+} from "@/constants/categories";
 
 export function ModernHeroSection() {
   const [searchValue, setSearchValue] = useState("");
@@ -31,15 +36,15 @@ export function ModernHeroSection() {
         {/* Stats */}
         <div className="grid grid-cols-3 gap-8 max-w-xl mx-auto text-center">
           <div>
-            <div className="text-sm text-gray-600">Rules</div>
+            <div className="text-sm text-gray-600">{CATEGORY_RULES}</div>
             <div className="text-2xl font-bold text-gray-900 mb-1">6개</div>
           </div>
           <div>
-            <div className="text-sm text-gray-600">프롬프트</div>
+            <div className="text-sm text-gray-600">{CATEGORY_PROMPTS}</div>
             <div className="text-2xl font-bold text-gray-900 mb-1">10개</div>
           </div>
           <div>
-            <div className="text-sm text-gray-600">Libraries</div>
+            <div className="text-sm text-gray-600">{CATEGORY_LIBRARIES}</div>
             <div className="text-2xl font-bold text-gray-900 mb-1">10개</div>
           </div>
         </div>

--- a/src/constants/categories.ts
+++ b/src/constants/categories.ts
@@ -1,0 +1,11 @@
+export const CATEGORY_RULES = "Rules";
+export const CATEGORY_PROMPTS = "Prompts";
+export const CATEGORY_LIBRARIES = "Libraries";
+
+export const CATEGORY_OPTIONS = [
+  CATEGORY_RULES,
+  CATEGORY_PROMPTS,
+  CATEGORY_LIBRARIES,
+] as const;
+
+export type CategoryOption = (typeof CATEGORY_OPTIONS)[number];


### PR DESCRIPTION
## Summary
- introduce category constants under `src/constants`
- update header, hero, and load more button to use constants
- create `/list` page that shows items filtered by category

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68411bb95d108331a272b7bcb870a2bc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new page that displays a selectable list of featured items by category, allowing users to filter and view items from "Rules", "Prompts", and "Libraries".
- **Refactor**
	- Replaced hardcoded category names with centralized constants across navigation, headers, buttons, and stats sections for consistency.
- **Chores**
	- Added a centralized module for category constants and types to streamline category management throughout the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->