### PR TITLE
Fix listener leak in useToast hook

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -182,7 +182,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- fix effect dependency to avoid listener leak

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684117e80b8483319b3c3736f2a5acf2