### PR TITLE
Add MCP deep link modal

### DIFF
--- a/src/components/mcp-guide-modal.tsx
+++ b/src/components/mcp-guide-modal.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+
+export function MCPGuideModal() {
+  const deeplink =
+    "cursor://anysphere.cursor-deeplink/mcp/install?name=vooster-ai&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsIi0tcGFja2FnZT1Adm9vc3Rlci9tY3AiLCJ2b29zdGVyLWFpIiwiLS1hcGkta2V5PWFrX3gwNWpvc2kxa3N0MXZqbWhxcDI0MDJmdSJdfQ==";
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button className="btn-primary">MCP 가이드</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>MCP 서버 사용 가이드</DialogTitle>
+        </DialogHeader>
+        <p className="text-sm text-gray-600 mt-2">
+          Vooster AI MCP 서버를 Cursor에 설치하려면 아래 버튼을 클릭하세요.
+        </p>
+        <div className="mt-4">
+          <Button asChild className="btn-primary">
+            <a href={deeplink}>Cursor로 바로 연동하기</a>
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default MCPGuideModal;

--- a/src/components/modern-header.tsx
+++ b/src/components/modern-header.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
+import MCPGuideModal from "./mcp-guide-modal";
 import { Menu, X } from "lucide-react";
 import Image from "next/image";
 
@@ -48,6 +49,7 @@ export function ModernHeader() {
 
             {/* Right side actions */}
             <div className="flex items-center space-x-4">
+              <MCPGuideModal />
               {/* GitHub link */}
               <Link
                 href="https://github.com/cursormatfia"


### PR DESCRIPTION
## Summary
- create `MCPGuideModal` with link to install `vooster-ai` MCP server via Cursor deeplink
- include the new modal in `ModernHeader`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68411cf7443883319f258bb83a538958

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a modal guide accessible from the header, providing instructions and a direct link to install the Vooster AI MCP server on Cursor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->